### PR TITLE
[docs/installation]: added note to guide

### DIFF
--- a/examples/book/src/pages/documentation/installation.rs
+++ b/examples/book/src/pages/documentation/installation.rs
@@ -34,6 +34,20 @@ pub fn PageInstallation(cx: Scope) -> impl IntoView {
             "In order to build your app with these styles, a build script is required. "
         </P>
 
+        <P>
+            "Now add a folder named "<Code inline=true>".cargo"</Code>" to the root and add a file to that folder named "<Code inline=true>"config.toml"</Code>". Then add the following contents to that file:"
+        </P>
+        
+        <Code>
+            {indoc!(
+                r#"
+                    [build]
+                    # The 'web_sys_unstable_apis' flag is required, because we use https://leptos-use.rs/elements/use_element_size.html which states this requirement. This might change in the future.
+                    rustflags = ["--cfg", "web_sys_unstable_apis"]
+                "#
+            )}
+        </Code>
+
         <P>"Let's create our "<Code inline=true>"build.rs"</Code>" file, generating our theme and copying required JS files."</P>
 
         <Code>


### PR DESCRIPTION
Added a note to Installation page to add .cargo/config.toml to set the `web_sys_unstable_apis` rustflag. This is a requirement for leptos-use.

Without this flag you'll run into the following errors when building:

```sh
   Compiling leptonic v0.1.0
error[E0432]: unresolved imports `leptos_use::use_element_size`, `leptos_use::UseElementSizeReturn`
 --> /Users/moi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leptonic-0.1.0/src/progress_bar.rs:2:18
  |
2 | use leptos_use::{use_element_size, UseElementSizeReturn};
  |                  ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^ no `UseElementSizeReturn` in the root
  |                  |
  |                  no `use_element_size` in the root
  |                  help: a similar name exists in the module: `use_element_hover`

error[E0432]: unresolved imports `leptos_use::use_element_size`, `leptos_use::UseElementSizeReturn`
 --> /Users/moi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leptonic-0.1.0/src/skeleton.rs:2:18
  |
2 | use leptos_use::{use_element_size, UseElementSizeReturn};
  |                  ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^ no `UseElementSizeReturn` in the root
  |                  |
  |                  no `use_element_size` in the root
  |                  help: a similar name exists in the module: `use_element_hover`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `leptonic` (lib) due to 2 previous errors
2023-08-07T18:47:13.004283Z ERROR ❌ error
error from HTML pipeline
```

This will save you some time figuring out how to resolve these errors as the implementation looked alright.

For more info see:
https://leptos-use.rs/elements/use_element_size.html